### PR TITLE
fix: scope scorecard workflow permissions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,14 +8,22 @@ on:
         branches: [main]
 
 permissions:
-    security-events: write
-    id-token: write
     contents: read
+    issues: read
+    pull-requests: read
+    checks: read
 
 jobs:
     analysis:
         name: Scorecard analysis
         runs-on: ubuntu-latest
+        permissions:
+            security-events: write
+            id-token: write
+            contents: read
+            issues: read
+            pull-requests: read
+            checks: read
         steps:
             - name: Checkout code
               uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- move Scorecard publish write permissions from workflow level to the analysis job
- keep explicit read permissions instead of `read-all`

## Verification
- parsed `.github/workflows/scorecard.yml` as YAML
- ran `git diff --check`

## Phase 4 context
Follow-up fix for the post-merge main Scorecard workflow failure after PR #30.