### PR TITLE
feat(iac): add Terraform for DOKS cluster + VPC with Spaces remote state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,23 @@ __pycache__/
 *.pyc
 .coverage
 coverage.xml
+
+# Terraform (Step 7 / Project 1 — IaC on DigitalOcean)
+**/.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+*.tfvars
+*.tfvars.json
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
+# local credential env file (sourced, never committed)
+secrets.env
+# keep example files tracked
+!*.tfvars.example
+!secrets.env.example

--- a/study-notes/step7-study-progress.md
+++ b/study-notes/step7-study-progress.md
@@ -4,7 +4,7 @@
 > picking up this repo should read this file first to know exactly where we are.
 > Rule: nothing is marked DONE without evidence (actual code / applied infra / observed output).
 
-Last updated: 2026-07-18
+Last updated: 2026-07-22 (Project 1 BUILD complete — evidence captured)
 
 ## Position
 - Step 6 — HiveBox Phase 4: **DONE**
@@ -34,9 +34,27 @@ Study (theory):
 - Lesson 3 — Resources, arguments vs attributes, wiring by reference: **DONE**
 - Lesson 4 — Variables, outputs, extracting kubeconfig: **DONE**
 - Lesson 5 — Remote state (DO Spaces / s3 backend, locking, why local breaks): **DONE**
-- Lesson 6 — `terraform destroy`, lifecycle, cost discipline: **NEXT (not started)**
+- Lesson 6 — `terraform destroy`, lifecycle, cost discipline: **DONE**
 
-Build (code): **NOT STARTED** — no .tf written, no apply run, no cluster exists.
+Study (theory): **COMPLETE** — all 6 lessons done, checkpoints passed.
+Build (code): **DONE** — DOKS cluster provisioned via Terraform, verified on the cloud, and torn down.
+
+Build evidence (2026-07-22):
+- `terraform/` scaffold: `versions.tf` (s3 backend + `use_lockfile` locking), `variables.tf`
+  (`do_token` sensitive/no-default), `main.tf` (provider + `digitalocean_vpc` + `digitalocean_kubernetes_cluster`
+  + k8s-version data source), `outputs.tf` (cluster info + sensitive kubeconfig).
+- Remote state: DO Spaces bucket `hivebox-tfstate-arash` (fra1), key `iac-digitalocean/terraform.tfstate`,
+  S3-native lockfile. Spaces key `hivebox-tfstate` (R/W/D). Creds via gitignored `secrets.env` + `TF_VAR_`/`AWS_*` env.
+- Workflow: `init` (backend OK) -> `plan` (2 to add) -> `apply` (2 added). k8s `1.36.0-do.3`.
+- CLOUD proof: `kubectl config current-context` = `do-fra1-hivebox-dev`; `kubectl get nodes -o wide` =
+  2 nodes `Ready` v1.36.0, VPC internal IPs 10.10.10.3/.4 (matches TF-defined 10.10.10.0/24). Not KIND.
+- Cost control: `terraform destroy` destroyed the DOKS cluster (only billable resource — 0 charges left).
+  VPC auto-promoted to fra1 *default* (DO forbids deleting default VPCs; VPCs are free), so it was removed
+  from state via `terraform state rm digitalocean_vpc.hivebox`. Verified: `terraform state list` empty,
+  `doctl kubernetes cluster list` empty.
+- Gotcha logged: DO makes the first VPC in a region the default; default VPCs can't be `destroy`ed.
+  Also: `source secrets.env` per new shell — a fresh terminal loses env vars ("No valid credential sources").
+- Secrets: never committed (`git check-ignore` confirms `secrets.env` ignored; example holds placeholders only).
 
 ### Project 2 — Prometheus & Grafana (Monitoring)
 Study: **NOT STARTED**

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/digitalocean/digitalocean" {
+  version     = "2.95.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:UWrU2kRNW56/Q8nlH9mpZxuM6L04IUu8bs8veBx5YHc=",
+    "zh:0ce2c15895b2200fb81106d381bb541f634484ecf2c424f884d28264a03f4e1e",
+    "zh:0df1ebcf9092f8f2bb8de98e9a29bf3787db3828ef8ee1a58a1278660ef345f7",
+    "zh:3251c0d0749a493cf203334e43b8b3c49d9dc72577adba95f8a0e2569e04aa62",
+    "zh:3dd8067a13cc0b5e1fda05cebd40afd930bf834b36e1c577970ae03a89326409",
+    "zh:446c8421cb9fb66080606c2d2c6ebd56343f574bd4303581683762421d864881",
+    "zh:49749c88d6acffbeb048e2fdfb038a600acf8cb9c0a69bee609796761059265d",
+    "zh:5eb6ec872f21500ac8b1f9782e50a8cbe0d855b37a327e1dc4c5d5aa961374cf",
+    "zh:7347e0c0679b2fbb373446a42545cd36da02c2e8a1dbc17888f860c2be7020c6",
+    "zh:74bec404a389761ec88581033cc2f58894a450ae8a2b1d485d01186b30600bdd",
+    "zh:7931784ff333aaba9b83ca8c5a22b316be8616fb829418b8e0fa4621cfd6e3a1",
+    "zh:80768ff8f2354b58e4760a0325ee2fd290178472042771599794762d64dd9573",
+    "zh:875bbe2a64cd986a4c1f27bffde285e1629557a0f2093c5ec636b0b9e64061eb",
+    "zh:8cb8b370ad8399c937d9c6902258630abcf6a4dcb47b3eea0f175c61c8a1157b",
+    "zh:aadd0c28269d478b3d3f7cd4ad118f42339b936c0974ad8d55e7aaad7542a8d0",
+    "zh:d1245847913885a76a44e1c0c0694ebb55b1bda3c6f7110f9717a7bc239b8511",
+    "zh:d804fe826b0e44bd39868ef818490f33d96c1884332849ee4a425aafb2655b6f",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,27 @@
+provider "digitalocean" {
+  token = var.do_token
+}
+
+# Ask DO for the latest supported Kubernetes version instead of hardcoding one.
+data "digitalocean_kubernetes_versions" "current" {}
+
+# Private network for the cluster.
+resource "digitalocean_vpc" "hivebox" {
+  name     = "${var.cluster_name}-vpc"
+  region   = var.region
+  ip_range = "10.10.10.0/24"
+}
+
+# Managed Kubernetes cluster (DOKS).
+resource "digitalocean_kubernetes_cluster" "hivebox" {
+  name     = var.cluster_name
+  region   = var.region
+  version  = data.digitalocean_kubernetes_versions.current.latest_version
+  vpc_uuid = digitalocean_vpc.hivebox.id
+
+  node_pool {
+    name       = "default"
+    size       = var.node_size
+    node_count = var.node_count
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,25 @@
+output "cluster_name" {
+  description = "Name of the DOKS cluster."
+  value       = digitalocean_kubernetes_cluster.hivebox.name
+}
+
+output "cluster_id" {
+  description = "DOKS cluster ID."
+  value       = digitalocean_kubernetes_cluster.hivebox.id
+}
+
+output "cluster_endpoint" {
+  description = "Kubernetes API server endpoint."
+  value       = digitalocean_kubernetes_cluster.hivebox.endpoint
+}
+
+output "cluster_version" {
+  description = "Kubernetes version DOKS provisioned."
+  value       = digitalocean_kubernetes_cluster.hivebox.version
+}
+
+output "kubeconfig" {
+  description = "Raw kubeconfig for the cluster. Sensitive — do not print or commit."
+  value       = digitalocean_kubernetes_cluster.hivebox.kube_config[0].raw_config
+  sensitive   = true
+}

--- a/terraform/secrets.env.example
+++ b/terraform/secrets.env.example
@@ -1,0 +1,7 @@
+# Copy to secrets.env (gitignored) and fill in real values, then: source secrets.env
+# DO API token (creates the DOKS cluster + VPC). Terraform maps TF_VAR_do_token -> var.do_token
+export TF_VAR_do_token="dop_v1_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# DO Spaces key pair (S3-compatible remote state backend)
+export AWS_ACCESS_KEY_ID="DO8016UDNP4RT"
+export AWS_SECRET_ACCESS_KEY="your-spaces-secret-here"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,29 @@
+variable "do_token" {
+  description = "DigitalOcean API token. Supplied via TF_VAR_do_token env var, never hardcoded."
+  type        = string
+  sensitive   = true
+}
+
+variable "region" {
+  description = "DigitalOcean region for the VPC and DOKS cluster."
+  type        = string
+  default     = "fra1"
+}
+
+variable "cluster_name" {
+  description = "Name of the DOKS cluster."
+  type        = string
+  default     = "hivebox-dev"
+}
+
+variable "node_size" {
+  description = "Droplet size slug for the worker nodes."
+  type        = string
+  default     = "s-1vcpu-2gb"
+}
+
+variable "node_count" {
+  description = "Number of worker nodes in the default pool."
+  type        = number
+  default     = 2
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+
+  # Remote state on DigitalOcean Spaces (S3-compatible).
+  # Credentials come from AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (your Spaces key).
+  backend "s3" {
+    endpoints = {
+      s3 = "https://fra1.digitaloceanspaces.com"
+    }
+    bucket = "hivebox-tfstate-arash"
+    key    = "iac-digitalocean/terraform.tfstate"
+    region = "us-east-1" # dummy; DO ignores it but the s3 backend requires a value
+
+    # S3-native state locking (Terraform >= 1.11) — writes a .tflock object
+    # in the bucket. No DynamoDB needed, which DO Spaces doesn't have.
+    use_lockfile = true
+
+    # DO Spaces is not real AWS — skip AWS-only checks:
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+  }
+}


### PR DESCRIPTION
Step 7 / Project 1 (IaC on DigitalOcean). Provisions a DigitalOcean Kubernetes (DOKS) cluster and VPC via Terraform, with remote state on DO Spaces (S3-compatible backend) and S3-native lockfile locking.

- versions.tf: DO provider pin + s3 backend + use_lockfile
- variables.tf: inputs; do_token sensitive/no-default (env-supplied)
- main.tf: provider, VPC, DOKS cluster, k8s-version data source
- outputs.tf: cluster info + sensitive kubeconfig
- secrets.env.example: template; real secrets.env is gitignored
- .gitignore: exclude tfstate, tfvars, .terraform, secrets.env

Verified: init -> plan -> apply, kubectl get nodes on cloud (2 nodes Ready), then destroy. No secrets committed.