### PR TITLE
fix(cd): authenticate to GHCR with GITHUB_TOKEN instead of GHCR_PAT

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,8 +20,8 @@ jobs:
               uses: docker/login-action@v3
               with:
                   registry: ghcr.io
-                  username: arashzitaly
-                  password: ${{ secrets.GHCR_PAT }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build and push versioned image
               uses: docker/build-push-action@v6


### PR DESCRIPTION
The CD login failed with 'denied: denied' because the GHCR_PAT secret was missing/expired. Use the workflow's built-in GITHUB_TOKEN (packages: write is already granted) so there is no PAT to manage or rotate.